### PR TITLE
Add hyphens and underscores to default date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Videos created with the `start_recording` action are XVID-encoded AVI files.
 To start recording a video, use the `start_recording` action, optionally providing a filename for the
 resulting .avi file and a recording duration.
 
-If the `filename` parameter is empty, the default format of `YYYYMMDDhhmmss.avi` will be used.  If the `filename`
+If the `filename` parameter is empty, the default format of `YYYY-MM-DD_hh-mm-ss.avi` will be used.  If the `filename`
 parameter is not empty, the `.avi` file extension should be included.  At present no other video encoding formats
 are supported.
 
@@ -152,7 +152,7 @@ uint32 time_remaining
 To save a single frame as an image, use the `save_image` action, optionally specifying the filename
 for the resulting image and a delay in seconds.
 
-If the `filename` parameter is empty, the default format of `YYYYMMDDhhmmss.png` will be used.  If the `filename`
+If the `filename` parameter is empty, the default format of `YYYY-MM-DD_hh-mm-ss.avi.png` will be used.  If the `filename`
 parameter is not empty, the file extension should be included in the parameter.  Supported extensions are:
 - `.png` (default),
 - `.jpg` (or `.jpeg`), and
@@ -265,8 +265,8 @@ Files created with the `start_recording` action are uncompressed `.wav` files.
 To start recording, use the `start_recording` action, optionally providing a filename for the
 resulting .avi file and a recording duration.
 
-If the `filename` parameter is empty, the default format of `YYYYMMDDhhmmss.wav` will be used.  If the `filename`
-parameter is not empty, the `.wav` file extension should be included.  At present no other audio formats
+If the `filename` parameter is empty, the default format of `YYYY-MM-DD_hh-mm-ss.avi.wav` will be used.  If the\
+`filename` parameter is not empty, the `.wav` file extension should be included.  At present no other audio formats
 are supported.
 
 If the `duration` parameter is zero the video will record until `stop_recording` is called (see below). otherwise the

--- a/audio_recorder/src/audio_recorder/audio_recorder_node.py
+++ b/audio_recorder/src/audio_recorder/audio_recorder_node.py
@@ -18,7 +18,7 @@ from std_msgs.msg import Bool
 from tf.transformations import euler_from_quaternion
 
 def defaultFilename():
-    return time.strftime("%Y%m%d%H%M%S")+".wav"
+    return time.strftime("%Y-%m-%d_%H-%M-%S")+".wav"
 
 class AudioRecorderNode:
     def __init__(self, output_dir, card_id=0, device_id=0, bitrate=44100, channels=1, record_metadata=False, mic_frame="mic_frame"):
@@ -66,7 +66,7 @@ class AudioRecorderNode:
     def notify_is_recording_changed(self):
         """Publish to the latched .../is_recording topic
         """
-        self.is_recording_pub.publish(Bool(self.is_recording))
+        %self.is_recording_pub.publish(Bool(self.is_recording))
 
     def startRecording_actionHandler(self, req):
         if self.is_recording:

--- a/video_recorder/src/video_recorder_node.cpp
+++ b/video_recorder/src/video_recorder_node.cpp
@@ -234,7 +234,7 @@ std::string VideoRecorderNode::defaultFilename(std::string extension)
   std::tm* timeinfo;
   std::time(&rawtime);
   timeinfo = std::localtime(&rawtime);
-  std::strftime(time_str,80,"%Y%m%d%H%M%S",timeinfo);
+  std::strftime(time_str,80,"%Y-%m-%d_%H-%M-%S",timeinfo);
   std::puts(time_str);
   ss << time_str << "." << extension;
 


### PR DESCRIPTION
Edit the default filenames to use e.g. "1970-01-01_12-34-56" instead of "19700101123456"