### PR TITLE
Add mount_path parameter

### DIFF
--- a/audio_recorder/launch/audio_recorder_node.launch
+++ b/audio_recorder/launch/audio_recorder_node.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <launch>
   <arg name="out_dir"      default="$(optenv HOME /tmp)" />
+  <arg name="mount_path"   default="" />
 
   <!-- ALSA device attributes -->
   <arg name="card" default="0" />
@@ -12,12 +13,13 @@
   <arg name="mic_frame" default="mic_frame" />
 
   <node pkg="audio_recorder" type="audio_recorder_node" name="audio_recorder_$(arg card)_$(arg device)">
-    <param name="out_dir"  value="$(arg out_dir)" />
-    <param name="card"     value="$(arg card)" />
-    <param name="device"   value="$(arg device)" />
-    <param name="bitrate"  value="$(arg bitrate)" />
-    <param name="channels" value="$(arg channels)" />
+    <param name="out_dir"    value="$(arg out_dir)" />
+    <param name="mount_path" value="$(arg mount_path)" />
+    <param name="card"       value="$(arg card)" />
+    <param name="device"     value="$(arg device)" />
+    <param name="bitrate"    value="$(arg bitrate)" />
+    <param name="channels"   value="$(arg channels)" />
     <param name="record_metadata" value="$(arg record_metadata)" />
-    <param name="mic_frame" value="$(arg mic_frame)" />
+    <param name="mic_frame"  value="$(arg mic_frame)" />
   </node>
 </launch>

--- a/audio_recorder/scripts/audio_recorder_node
+++ b/audio_recorder/scripts/audio_recorder_node
@@ -11,10 +11,11 @@ def main():
     bitrate = rospy.get_param('~bitrate', 44100)
     channels = rospy.get_param('~channels', 1)
     out_dir = rospy.get_param('~out_dir', '/tmp')
+    mount_dir = rospy.get_param('~mount_path', '')
     record_metadata = rospy.get_param('~record_metadata', False)
     mic_frame = rospy.get_param('~mic_frame', 'mic_frame')
 
-    node = AudioRecorderNode(out_dir, card, device, bitrate, channels, record_metadata, mic_frame)
+    node = AudioRecorderNode(out_dir, mount_dir, card, device, bitrate, channels, record_metadata, mic_frame)
     node.run()
 
 if __name__=="__main__":

--- a/video_recorder/include/video_recorder/video_recorder_node.hpp
+++ b/video_recorder/include/video_recorder/video_recorder_node.hpp
@@ -34,6 +34,7 @@ namespace video_recorder
     VideoRecorderNode(ros::NodeHandle &nh,
       const std::string &img_topic,
       const std::string &out_dir,
+      const std::string &mount_path,
       const std::string &camera_frame,
       const double fps,
       const double output_height,
@@ -58,6 +59,7 @@ namespace video_recorder
     // ROS parameters
     std::string img_topic_;
     std::string out_dir_;
+    std::string mount_path_;
     std::string camera_frame_;
     double fps_;
     int output_height_;
@@ -94,6 +96,7 @@ namespace video_recorder
     std::chrono::duration<unsigned long, std::ratio<1> > max_video_duration_;
     std::chrono::time_point<std::chrono::system_clock> video_start_time_;
     std::string video_path_;
+    std::string video_result_path_;
     cv::VideoWriter *vout_;
     cv::VideoWriter *createVideoWriter();
     void appendFrame(const cv::UMat &img);
@@ -104,6 +107,7 @@ namespace video_recorder
     bool capture_next_frame_;
     bool image_saved_;
     std::string image_path_;
+    std::string image_result_path_;
     void saveImage(const cv::UMat &img);
 
     // General Utilities

--- a/video_recorder/launch/video_recorder_node.launch
+++ b/video_recorder/launch/video_recorder_node.launch
@@ -3,6 +3,7 @@
   <arg name="compressed"       default="false" />
   <arg name="fps"              default="30" />
   <arg name="out_dir"          default="$(optenv HOME /tmp)" />
+  <arg name="mount_path"       default="" />
   <arg name="topic"            default="/camera/image_raw" />
   <arg name="video_height"     default="480" />
   <arg name="video_width"      default="640" />
@@ -14,6 +15,7 @@
       <param name="compressed"       value="$(arg compressed)" />
       <param name="fps"              value="$(arg fps)" />
       <param name="out_dir"          value="$(arg out_dir)" />
+      <param name="mount_path"       value="$(arg mount_path)" />
       <param name="topic"            value="$(arg topic)" />
       <param name="output_height"    value="$(arg video_height)" />
       <param name="output_width"     value="$(arg video_width)" />


### PR DESCRIPTION
When the recorder nodes are run inside a Docker container, the returned paths are relative _within_ the container, and may be meaningless to the host OS.

Add `mount_path` parameters to the audio_recorder and video_recorder nodes. If non-empty, these paths replace the value of `out_dir` in the result path of the start/stop recording actions of both nodes + the save_image action of the video_recorder node.

e.g. If `out_dir` is set to `/saved_media/camera_0` and `mount_path` is set to `/home/user/docker_media` (assuming the video recorder node is running inside a docker container, with the docker_media directory mounted inside it), the `save_image` action's result will be of the form `/home/user/docker_media/foo.png`, and not `/saved_media/camera_0/foo.png`.