### PR TITLE
Add a header to the result objects for all actions

### DIFF
--- a/audio_recorder/src/audio_recorder/audio_recorder_node.py
+++ b/audio_recorder/src/audio_recorder/audio_recorder_node.py
@@ -75,6 +75,8 @@ class AudioRecorderNode:
             result = StartRecordingResult()
             result.success = False
             result.path = self.result_path
+            result.header.stamp = ros::Time::now();
+            result.header.frame_id = camera_frame_;
             self.start_recording_srv.set_succeeded(result)
             return
 
@@ -128,6 +130,8 @@ class AudioRecorderNode:
         result = StartRecordingResult()
         result.success = True
         result.path = self.result_path
+        result.header.stamp = rospy.Time.now()
+        result.header.frame_id = self.mic_frame
         self.start_recording_srv.set_succeeded(result)
 
 
@@ -136,6 +140,8 @@ class AudioRecorderNode:
             rospy.logwarn("Unable to stop recording; no recording in progress")
             result = StopRecordingResult()
             result.success = False
+            result.header.stamp = rospy.Time.now()
+            result.header.frame_id = self.mic_frame
             self.stop_recording_srv.set_succeeded(result)
             return
 
@@ -147,6 +153,8 @@ class AudioRecorderNode:
         result.success = True
         result.path = self.result_path
         result.duration = int(elapsed.to_sec())
+        result.header.stamp = rospy.Time.now()
+        result.header.frame_id = self.mic_frame
 
         self.is_recording = False
         self.notify_is_recording_changed()

--- a/audio_recorder_msgs/action/StartRecording.action
+++ b/audio_recorder_msgs/action/StartRecording.action
@@ -1,6 +1,7 @@
 string filename
 uint64 duration
 ---
+std_msgs/Header header
 bool success
 string path
 ---

--- a/audio_recorder_msgs/action/StopRecording.action
+++ b/audio_recorder_msgs/action/StopRecording.action
@@ -1,5 +1,6 @@
 bool arg
 ---
+std_msgs/Header header
 bool success
 string path
 uint64 duration

--- a/video_recorder/src/video_recorder_node.cpp
+++ b/video_recorder/src/video_recorder_node.cpp
@@ -320,12 +320,16 @@ void VideoRecorderNode::startRecordingHandler(const video_recorder_msgs::StartRe
       stopRecording();
       result.path = video_result_path_;
       result.success = false;
+      result.header.stamp = ros::Time::now();
+      result.header.frame_id = camera_frame_;
       start_service_.setAborted(result, "User cancelled fixed-duration video");
     }
 
     // return the result
     result.path = video_result_path_;
     result.success = true;
+    result.header.stamp = ros::Time::now();
+    result.header.frame_id = camera_frame_;
     start_service_.setSucceeded(result);
   }
   else
@@ -333,6 +337,8 @@ void VideoRecorderNode::startRecordingHandler(const video_recorder_msgs::StartRe
     ROS_WARN("Unable to start recording; node is already recording to %s", video_path_.c_str());
     result.path = video_result_path_;
     result.success = false;
+    result.header.stamp = ros::Time::now();
+    result.header.frame_id = camera_frame_;
     start_service_.setSucceeded(result);
   }
 }
@@ -361,6 +367,8 @@ void VideoRecorderNode::stopRecordingHandler(const video_recorder_msgs::StopReco
     result.path = video_result_path_;
     result.size = filesize(video_path_);
     result.success = true;
+    result.header.stamp = ros::Time::now();
+    result.header.frame_id = camera_frame_;
     stop_service_.setSucceeded(result);
   }
   else
@@ -370,6 +378,8 @@ void VideoRecorderNode::stopRecordingHandler(const video_recorder_msgs::StopReco
     result.path = "";
     result.size = 0;
     result.success = false;
+    result.header.stamp = ros::Time::now();
+    result.header.frame_id = camera_frame_;
     stop_service_.setSucceeded(result);
   }
 }
@@ -444,6 +454,8 @@ void VideoRecorderNode::saveImageHandler(const video_recorder_msgs::SaveImageGoa
 
     result.path = image_result_path_;
     result.success = true;
+    result.header.stamp = ros::Time::now();
+    result.header.frame_id = camera_frame_;
     frame_service_.setSucceeded(result);
     status_.status &= ~video_recorder_msgs::Status::PHOTO_TIMER;
   }
@@ -452,6 +464,8 @@ void VideoRecorderNode::saveImageHandler(const video_recorder_msgs::SaveImageGoa
     ROS_WARN("Already queued to record the next frame");
     result.path = image_result_path_;
     result.success = false;
+    result.header.stamp = ros::Time::now();
+    result.header.frame_id = camera_frame_;
     frame_service_.setSucceeded(result);
   }
 }

--- a/video_recorder_msgs/action/SaveImage.action
+++ b/video_recorder_msgs/action/SaveImage.action
@@ -1,6 +1,7 @@
 string filename
 uint32 delay
 ---
+std_msgs/Header header
 bool success
 string path
 ---

--- a/video_recorder_msgs/action/StartRecording.action
+++ b/video_recorder_msgs/action/StartRecording.action
@@ -1,6 +1,7 @@
 string filename
 uint64 duration
 ---
+std_msgs/Header header
 bool success
 string path
 ---

--- a/video_recorder_msgs/action/StopRecording.action
+++ b/video_recorder_msgs/action/StopRecording.action
@@ -1,5 +1,6 @@
 bool arg
 ---
+std_msgs/Header header
 bool success
 string path
 uint64 size


### PR DESCRIPTION
Add a header to the response objects so we can include a timestamp and the sensor frame ID